### PR TITLE
set .gitattributes file so git leaves line endings alone.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-* text eol=crlf
+* -text
 *.sh eol=lf


### PR DESCRIPTION
This prevents the minit.asm/.obj files from being modified by git.
